### PR TITLE
feat: 新增ArrayLike特征类型并为部分数据类型添加`__array__`协议

### DIFF
--- a/zjb/main/data/base.py
+++ b/zjb/main/data/base.py
@@ -1,0 +1,17 @@
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from zjb.dos.data import Data
+
+from ..trait_types import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
+
+
+class ArrayData(Data):
+    data = ArrayLike()
+
+    def __array__(self, dtype: "DTypeLike" = None):
+        return np.asarray(self.data, dtype=dtype)

--- a/zjb/main/data/correlation.py
+++ b/zjb/main/data/correlation.py
@@ -1,27 +1,27 @@
 import numpy as np
-from traits.api import Array, ArrayOrNone
+from traits.api import ArrayOrNone
 
 from zjb._traits.types import Instance
-from zjb.dos.data import Data
 
 from ..dtb.atlas import RegionSpace
+from .base import ArrayData
 from .space import Space
 
 
-class SpaceCorrelation(Data):
+class SpaceCorrelation(ArrayData):
     """空间相关, 特定空间内任意两个点之间的相关程度
+
+    空间相关是一个ArrayLike, 可以使用np.asarray或np.array获取空间相关的数据
 
     Attrs
     =====
     space: Space
         空间, 定义相关所在的空间
-    data: np.ndarray[space_shape+space_shape, dtype[float]]
+    data: array, shape (*space.shape,) + (*space.shape,)
         相关数组, 空间中任意两个点的相关程度
     """
 
     space = Instance(Space)
-
-    data = Array()
 
 
 class Connectivity(SpaceCorrelation):

--- a/zjb/main/data/regionmapping.py
+++ b/zjb/main/data/regionmapping.py
@@ -4,16 +4,17 @@ import numpy as np
 from traits.api import Array
 
 from zjb._traits.types import Instance
-from zjb.dos.data import Data
 from zjb.main.data.space import SurfaceSpace, VolumeSpace
 from zjb.main.dtb.atlas import Atlas
 from zjb.main.trait_types import RequiredIntVector
+
+from .base import ArrayData
 
 if TYPE_CHECKING:
     from nibabel.gifti.gifti import GiftiImage
 
 
-class SurfaceRegionMapping(Data):
+class SurfaceRegionMapping(ArrayData):
     """
     表面区域映射类。该类用于创建和处理表面区域映射。
 
@@ -23,9 +24,10 @@ class SurfaceRegionMapping(Data):
         表面空间实例，表示数据所在的空间。
     atlas : Atlas
         图谱实例，用于区域映射。
-    data : RequiredIntVector
+    data : array[int] shape (n_nodes)
         整型向量表示的映射数据。
     """
+
     space = Instance(SurfaceSpace, required=True)
 
     atlas = Instance(Atlas, required=True)
@@ -108,7 +110,7 @@ class SurfaceRegionMapping(Data):
         return cls(space=space, atlas=atlas, data=mat)
 
 
-class VolumeRegionMapping(Data):
+class VolumeRegionMapping(ArrayData):
     """
     体素空间映射类。
 
@@ -120,9 +122,10 @@ class VolumeRegionMapping(Data):
         体素空间的实例。
     atlas : Atlas
         图谱的实例。
-    data : Array
+    data : array[int], shape (nx, ny, nz)
         包含映射数据的 NumPy 数组。
     """
+
     volume = Instance(VolumeSpace, required=True)
 
     atlas = Instance(Atlas, required=True)

--- a/zjb/main/data/series.py
+++ b/zjb/main/data/series.py
@@ -2,12 +2,13 @@ import pickle
 from enum import Enum as ZJBEnum
 
 import numpy as np
-from traits.api import Array, Enum, Float, Int, Property, Str
+from traits.api import Enum, Float, Int, Property
 
 from zjb._traits.types import Instance
-from zjb.dos.data import Data
 from zjb.main.data.space import Space
-from zjb.main.dtb.atlas import Atlas, RegionSpace
+from zjb.main.dtb.atlas import RegionSpace
+
+from .base import ArrayData
 
 
 class TimeUnit(ZJBEnum):
@@ -31,23 +32,21 @@ class TimeUnit(ZJBEnum):
     SECOND = "s"
 
 
-class SpaceSeries(Data):
+class SpaceSeries(ArrayData):
     """
-       空间序列类。
+    空间序列类。
 
-       该类用于表示与空间相关的数据序列。
+    该类用于表示与空间相关的数据序列。
 
-       Attributes
-       ----------
-       space : Space
-           空间实例。
-       data : Array
-           包含空间序列数据的 NumPy 数组。
-       """
+    Attributes
+    ----------
+    space : Space
+        空间实例。
+    data : array
+        包含空间序列数据的 NumPy 数组。
+    """
 
     space = Instance(Space)
-
-    data = Array()
 
 
 class TimeSeries(SpaceSeries):

--- a/zjb/main/trait_types.py
+++ b/zjb/main/trait_types.py
@@ -1,3 +1,4 @@
+import numpy as np
 from traits.api import Array
 
 IntVector = Array(dtype=int, shape=(None,))
@@ -9,3 +10,38 @@ RequiredIntVector = Array(dtype=int, shape=(None,), required=True)
 RequiredFloatVector = Array(dtype=float, shape=(None,), required=True)
 RequiredStrVector = Array(dtype=str, shape=(None,), required=True)
 RequiredBoolVector = Array(dtype=bool, shape=(None,), required=True)
+
+
+class ArrayLike(Array):
+    """ArrayLike是一个numpy数组, 或支持__array__协议的类型, 或列表和元组.
+
+    相较于traits库提供的Array扩展了对支持`__array__`协议的类型的支持
+
+    对于支持`__array__`协议的类型(不包括ndarray,list和tuple), ArrayLike会
+    保存其原始对象(这是为了能利用Data的引用保存), 因此需要注意在使用ArrayLike
+    的值之前可能要调用`np.asarray`将数据转换为合适的ndarray类型。
+    """
+
+    def validate(self, object, name, value):
+        # 使用父类验证值
+        if hasattr(value, "__array__"):
+            # 提前调用asarray以绕过父类的限制
+            super().validate(object, name, np.asarray(value))
+            # 返回转换前的值
+            return value
+        else:
+            return super().validate(object, name, value)
+
+
+class CArrayLike(Array):
+    """CArrayLike是一个numpy数组, 或支持__array__协议的类型, 或列表和元组
+
+    相比与ArrayLike, CArrayLike的值会被强制转换为ndarray类型, 而不会保留原始值
+    """
+
+    def validate(self, object, name, value):
+        if hasattr(value, "__array__"):
+            # 提前调用asarray已绕过父类的限制
+            value = np.asarray(value)
+        # 使用父类验证值并返回
+        return super().validate(object, name, value)


### PR DESCRIPTION
numpy的`__array__`协议(https://numpy.org/doc/stable/user/basics.interoperability.html#the-array-method )可以使任意对象能够使用numpy的API操作，在`zjb.main.data`模块中定义的很多类核心都是一个Numpy数组（只是增加了一些属性扩展其功能），因此为这些类添加`__array__`协议有助于更方便的使用这些对象。

ArryLike特征类型则扩展了traits库的Array特征类型，使得支持`__array__`协议的对象也可以作为特征值，使以上自定义的数据类型可以被当作一个numpy数组使用。ArrayLike不会将支持`__array__`协议的对象像ilst或tuple一样转换为ndarray类型，这是为了保留对象本身的其他功能或减少不必要的复制开销等。但这在部分情况下（如用于Numba中）可能需要先使用`asarray`将对象转换为ndarray类型，使用CArrayLike能够将支持`__array__`协议的对象强制转换为ndarray，但这可能产生额外的内存或存储开销。